### PR TITLE
Enable importing of css files

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -128,6 +128,16 @@ class SassCompiler extends MultiFileCachingCompiler {
         }
       }
 
+      // css files won't be in allFiles so try loading directly
+      for(const possibleFile of possibleFiles){
+        if(possibleFile.match(/\.css$/) && !isAbsolute){
+          let decodedPath = decodeFilePath(possibleFile);
+          if(fileExists(decodedPath)){
+            return {absolute:true,path:decodedPath};
+          }
+        }
+      }
+
       //Nothing found...
       return null;
 


### PR DESCRIPTION
I need to be able to include regular css files from npm packages, and as I understand it, both libsass and node_sass in other toolchains support this now. Also, from the code in this package it looks like that was the intention (css is one of the extensions that is considered if no extension is present).

However, css files don't appear in the allFiles map so any form of import other than a fully absolute path does not work. Maybe this changed in recent meteor releases (I'm using 1.5.1)?
I even tried using the sccs-config.json but again, that only seems to work for css files if full absolute paths are specified.

So this change adds a step to look for css files in the filesystem after trying the normal way.
I narrowed the check down to only consider files ending in .css to limit the risk of breaking something.

For future reference, the most useful/recent conclusions I found were in this SO question: https://stackoverflow.com/questions/7111610/import-regular-css-file-in-scss-file/30279590#30279590