### PR TITLE
sass/node-sass -> sass/dart-sass

### DIFF
--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.registerBuildPlugin({
   use: ['caching-compiler@1.2.0', 'ecmascript@0.12.0'],
   sources: ['plugin/compile-scss.js'],
   npmDependencies: {
-    'node-sass': '4.12.0',
+    'sass': '1.26.10',
   },
 });
 


### PR DESCRIPTION
To overcome the issue https://github.com/Meteor-Community-Packages/meteor-scss/issues/294 we can switch to https://www.npmjs.com/package/sass .

This code works quite well for my project. Our css person uses :not selector extensively so it's not viable to change codebase.

Also, the original node-sass issue (https://github.com/sass/node-sass/issues/2330) seems to exist for a couple years already, therefore it's not clear when and if it will be resolved.