### PR TITLE
Fix #273 and #246 

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -138,7 +138,7 @@ class SassCompiler extends MultiFileCachingCompiler {
 
     };
 
-    const makeAbsolute = function(thePath) {
+    const fixTilde = function(thePath) {
       let newPath = thePath;
       // replace ~ with {}/....
       if (newPath.startsWith('~')) {
@@ -159,7 +159,7 @@ class SassCompiler extends MultiFileCachingCompiler {
     //Handle import statements found by the sass compiler, used to handle cross-package imports
     const importer = function(url, prev, done) {
 
-      let absPrev = makeAbsolute(prev);
+      let absPrev = fixTilde(prev);
 
       if (!totalImportPath.length) {
         totalImportPath.push(absPrev);
@@ -172,7 +172,7 @@ class SassCompiler extends MultiFileCachingCompiler {
       }
 
       let importPath = url;
-      importPath = makeAbsolute(importPath);
+      importPath = fixTilde(importPath);
       const importPathFixed = importPath;
 
       for (let i = totalImportPath.length - 1; i >= 0; i--) {

--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -142,8 +142,7 @@ class SassCompiler extends MultiFileCachingCompiler {
       let newPath = thePath;
       // replace ~ with {}/....
       if (newPath.startsWith('~')) {
-        // importPath = importPath.replace('~', '{}/node_modules/');
-        newPath = newPath.replace('~', '{}/imports/ui/packages/');
+        newPath = newPath.replace('~', '{}/node_modules/');
       }
 
       // add {}/ if starts with node_modules


### PR DESCRIPTION
In some npm packages ~ (tilde) is used as shortcut for {}/node_modules (see #246). In this pull request I replace ~ with {}/mode_modules. 

For me this also fixed problems with "_includePaths is not iterable" (see #273)