### PR TITLE
Fix duplicate files not imported, and other fixes

### DIFF
--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -138,7 +138,7 @@ class SassCompiler extends MultiFileCachingCompiler {
 
     };
 
-    const makeAbsolute = function(thePath) {
+    const fixTilde = function(thePath) {
       let newPath = thePath;
       // replace ~ with {}/....
       if (newPath.startsWith('~')) {
@@ -159,7 +159,7 @@ class SassCompiler extends MultiFileCachingCompiler {
     //Handle import statements found by the sass compiler, used to handle cross-package imports
     const importer = function(url, prev, done) {
 
-      let absPrev = makeAbsolute(prev);
+      let absPrev = fixTilde(prev);
 
       if (!totalImportPath.length) {
         totalImportPath.push(absPrev);
@@ -172,7 +172,7 @@ class SassCompiler extends MultiFileCachingCompiler {
       }
 
       let importPath = url;
-      importPath = makeAbsolute(importPath);
+      importPath = fixTilde(importPath);
       const importPathFixed = importPath;
 
       for (let i = totalImportPath.length - 1; i >= 0; i--) {

--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -208,8 +208,7 @@ class SassCompiler extends MultiFileCachingCompiler {
       }
       
       try {
-        const isAbsolute = importPath.startsWith('/');
-        let parsed = getRealImportPath(importPath, isAbsolute);
+        let parsed = getRealImportPath(importPath);
 
         if (!parsed) {
           parsed = _getRealImportPathFromIncludes(url, getRealImportPath);

--- a/plugin/compile-scss.js
+++ b/plugin/compile-scss.js
@@ -142,8 +142,7 @@ class SassCompiler extends MultiFileCachingCompiler {
       let newPath = thePath;
       // replace ~ with {}/....
       if (newPath.startsWith('~')) {
-        // importPath = importPath.replace('~', '{}/node_modules/');
-        newPath = newPath.replace('~', '{}/imports/ui/packages/');
+        newPath = newPath.replace('~', '{}/node_modules/');
       }
 
       // add {}/ if starts with node_modules


### PR DESCRIPTION
This should fix at least issues: #289, #246, #239 and #253. 

The main inspiration for this fix comes from: https://github.com/sass/node-sass/issues/2556

which says to add file parameter even when passing comment, like so:
```js
done({ contents: fs.readFileSync(parsed.path, 'utf8'), file: parsed.path});
```