### PR TITLE
Accept version 2.0 of caching-compiler

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.registerBuildPlugin({
   name: 'compileScssBatch',
-  use: ['caching-compiler@1.2.2', 'ecmascript@0.15.1'],
+  use: ['caching-compiler@1.2.2 || 2.0.0', 'ecmascript@0.15.1'],
   sources: ['plugin/compile-scss.js'],
   npmDependencies: {
     'node-sass': '4.14.1',


### PR DESCRIPTION
Meteor 3.0 has a major version bump of the caching-compiler package due to some changes in the API. However, none of those are changes that affect this package's integration with caching-compiler, so we can safely accept a dependency on either version.

It's fairly easy to see that the current version of `fourseven:scss` isn't compatible:

```
evan@mathias src % meteor create --minimal --release 3.0-alpha.16 meteor-test
[...]
evan@mathias src % cd meteor-test
evan@mathias meteor-test % meteor add fourseven:scss@4.15.0
 => Errors while adding packages:

While selecting package versions:
error: Conflict: Constraint caching-compiler@1.2.2 is not satisfied by caching-compiler 2.0.0-alpha300.16.
Constraints on package "caching-compiler":
* caching-compiler@~2.0.0-alpha300.16 <- top level
* caching-compiler@2.0.0-alpha300.16 <- caching-html-compiler 2.0.0-alpha300.16 <- static-html 1.3.3-alpha300.16
* caching-compiler@1.2.2 <- fourseven:scss 4.15.0
```

You can see the differences to the `caching-compiler` package in [this gist](https://gist.github.com/ebroder/59162a4dcacc783e5503369da6b183f0). I believe the change to the `afterLink` method means that a major version bump is technically appropriate, if unfortunate from a usability standpoint.