### PR TITLE
Make it compatible with 3.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,22 +1,26 @@
 Package.describe({
   summary: 'Style with attitude. Sass and SCSS support for Meteor.js.',
-  version: '4.15.1',
+  version: '4.16.0',
   git: 'https://github.com/Meteor-Community-Packages/meteor-scss.git',
   name: 'fourseven:scss',
 });
 
 Package.registerBuildPlugin({
   name: 'compileScssBatch',
-  use: ['caching-compiler@1.2.2 || 2.0.0', 'ecmascript@0.15.1'],
+  use: [
+    'caching-compiler',
+    'ecmascript'
+  ],
   sources: ['plugin/compile-scss.js'],
   npmDependencies: {
-    'node-sass': '4.14.1',
-  },
-});
+    "node-sass": '9.0.0',
+    "@babel/runtime": "7.24.5"
+  }
+})
 
 Package.onUse(function(api) {
-  api.versionsFrom('2.3');
-  api.use('isobuild:compiler-plugin@1.0.0');
+  api.versionsFrom(['2.3', '3.0-rc.0']);
+  api.use('isobuild:compiler-plugin');
 });
 
 Package.onTest(function(api) {


### PR DESCRIPTION
I've lifted the changes that we did to this package to get it working with the latest RC, as I already explained [here](https://github.com/Meteor-Community-Packages/meteor-scss/pull/318#issuecomment-2122095107). cc @jankapunkt @StorytellerCZ  

~~It's important to note that you'd need to fork caching-compiler package and modify lru cache code in `multi-file-caching-compiler` for meteor-scss to work with the latest RC.~~
```js
    // Maps from cache key to { compileResult, cacheKeys }, where
    // cacheKeys is an object mapping from absolute import path to hashed
    // cacheKey for each file referenced by this file (including itself).
    this._cache = new LRU({
      max: this._cacheSize,
      maxSize: this._cacheSize,
      // We ignore the size of cacheKeys here.
      sizeCalculation: (value) => this.compileResultSize(value.compileResult),
    });
```
EDIT: **It's no longer needed to fork caching-compiler as of `3.0-rc.3`**

Maybe in the future we can find a way to merge https://github.com/leonardoventurini/meteor-scss and https://github.com/activitree/scss together in a breaking change that drops support for Meteor imports??